### PR TITLE
Debug netlify build type errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,7 +150,7 @@ function CustomAmountModal({
                      <BuiAmountOptionTile
              showMessage={false}
              showEmoji={false}
-             primaryAmount={currentAmount}
+             primaryAmount={parseFloat(currentAmount) || 0}
              secondaryAmount={isLoadingPrice ? 0 : satoshis}
              showSecondaryCurrency={true}
              secondarySymbol={'₿'}
@@ -168,14 +168,14 @@ function CustomAmountModal({
             <BuiButton
               label="Go Back"
               styleType="outline"
-              wide={true}
+              wide="true"
               onClick={onClose}
             >
             </BuiButton>
                          <BuiButton
                label="Continue"
-               wide={true}
-               disabled={!isAmountValid}
+               wide="true"
+               disabled={!isAmountValid ? "true" : "false"}
                onClick={handleConfirm}
              >
             </BuiButton>
@@ -390,7 +390,7 @@ function App() {
           <BuiAmountOptionTile
             custom={true}
             amountDefined={currentInputAmount !== '0'}
-            primaryAmount={currentInputAmount}
+            primaryAmount={parseFloat(currentInputAmount) || 0}
             secondaryAmount={customAmountSats}
             showSecondaryCurrency={true}
             secondarySymbol={'₿'}
@@ -406,10 +406,10 @@ function App() {
       {!isLoadingPrices && (
         <div className="text-center">
           <BuiButton
-            style-type="filled"
+            styleType="filled"
             size="large"
             label="Continue"
-            disabled={!selectedAmount}
+            disabled={!selectedAmount ? "true" : "false"}
             onClick={handleContinue}
           />
         </div>

--- a/src/components/ReceiveScreen.tsx
+++ b/src/components/ReceiveScreen.tsx
@@ -148,15 +148,15 @@ export default function ReceiveScreen({ amount, bitcoinAmount, onGoBack, onCopy 
       {/* Amount Display */}
       <div className="flex items-center gap-8">
         <BuiMoneyValue
-          amount={amount}
+          amount={amount.toString()}
           symbol="$"
-          showEstimate={true}
+          showEstimate="true"
           textSize="3xl"
         />
         <span className="text-[var(--text-secondary)]">
           <BuiBitcoinValue
-            amount={bitcoinAmount}
-            showEstimate={false}
+            amount={bitcoinAmount.toString()}
+            showEstimate="false"
             textSize="3xl"
           />
         </span>
@@ -169,15 +169,15 @@ export default function ReceiveScreen({ amount, bitcoinAmount, onGoBack, onCopy 
           lightning={paymentData?.lightningInvoice || ''}
           option="lightning"
           selector="toggle"
-          size={264}
-          showImage={true}
+          size="264"
+          showImage="true"
           dotType="dot"
           dotColor="#000000"
-          copyOnTap={true}
-          placeholder={isLoading}
-          error={!!error}
+          copyOnTap="true"
+          placeholder={isLoading ? "true" : "false"}
+          error={error ? "true" : "false"}
           errorMessage={error || undefined}
-          complete={isPaymentComplete}
+          complete={isPaymentComplete ? "true" : "false"}
         />
       </div>
 
@@ -188,7 +188,7 @@ export default function ReceiveScreen({ amount, bitcoinAmount, onGoBack, onCopy 
             label="Leave Another Tip"
             styleType="filled"
             size="large"
-            wide={true}
+            wide="true"
             onClick={handleLeaveAnotherTip}
           >
             <CheckCircleIcon />
@@ -199,8 +199,8 @@ export default function ReceiveScreen({ amount, bitcoinAmount, onGoBack, onCopy 
               label={isCopied ? "Copied!" : (isLoading ? "Loading..." : "Copy")}
               styleType="filled"
               size="large"
-              wide={true}
-              disabled={isLoading || !!error || !paymentData}
+              wide="true"
+              disabled={isLoading || !!error || !paymentData ? "true" : "false"}
               onClick={handleCopy}
             >
               {isCopied ? <CheckCircleIcon /> : <CopyIcon />}
@@ -209,7 +209,7 @@ export default function ReceiveScreen({ amount, bitcoinAmount, onGoBack, onCopy 
               label="Go Back"
               styleType="outline"
               size="large"
-              wide={true}
+              wide="true"
               onClick={onGoBack}
             >
               <ArrowLeftIcon />


### PR DESCRIPTION
Fixes Netlify build failure by correcting TypeScript type mismatches for props in `@sbddesign/bui-ui` components.

The Netlify build environment enforced stricter TypeScript type checking, causing the build to fail due to components expecting string types for props like `amount`, `wide`, `disabled`, `size`, `showEstimate`, `copyOnTap`, `placeholder`, `error`, and `complete`, while they were being passed numbers or booleans. This PR converts these values to strings to satisfy the component prop types.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0ddc382-efe4-43d9-afa8-28253f607feb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0ddc382-efe4-43d9-afa8-28253f607feb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

